### PR TITLE
Parsing error: Missing '}' or object member name fix

### DIFF
--- a/src/components/PageHead.tsx
+++ b/src/components/PageHead.tsx
@@ -78,7 +78,7 @@ const PageHead: React.FC<{
               "@type": "Organization",
               "name": "CNCF",
               "alternateName": "Cloud Native Computing Foundation",
-              "url": "//cncf.io",  
+              "url": "//cncf.io"
             },
             "url": "//crossplane.io",
             "logo": "//raw.githubusercontent.com/crossplane/artwork/master/logo/logo-horizontal-whitetext-bluebg.png",


### PR DESCRIPTION
Remove comma  implying there is a new property following

Signed-off-by: Nicole <nicole@unomena.com>