### PR TITLE
Create an OWNERS file

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,21 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the [Crossplane
+organization](https://github.com/crossplane/) will list their repository maintainers in their own
+`OWNERS.md` file.
+
+Please see the Crossplane
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
+guidelines and responsibilities for the steering committee and maintainers.
+
+## Maintainers
+
+* Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+* Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred))
+* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+* Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis))
+
+## Emeritus maintainers
+
+* Connor Chan <connor@upbound.io> ([connorchan](https://github.com/connorchan))


### PR DESCRIPTION
Matches the OWNERS file in the docs repo. https://github.com/crossplane/docs/blob/master/OWNERS.md

Resolves #11

Signed-off-by: Pete Lumbis <pete@upbound.io>