### PR TITLE
Add revalidate-all api for news banner

### DIFF
--- a/pages/api/revalidate-all.ts
+++ b/pages/api/revalidate-all.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const paths = ['/', '/community', '/why-control-planes', '/privacy-policy'];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    await Promise.all(paths.map((path) => res.revalidate(path)));
+    return res.json({ revalidated: true });
+  } catch (err) {
+    console.log(err);
+    return res.status(500).send('Error revalidating');
+  }
+}


### PR DESCRIPTION
Added a revalidate-all api to allow the BE to revalidate all pages when the news banner is updated.

https://unomena.atlassian.net/browse/UP-424