### PR TITLE
chore(PageFooter): update trademark date to match current year

### DIFF
--- a/src/components/PageFooter.tsx
+++ b/src/components/PageFooter.tsx
@@ -175,7 +175,7 @@ Props) => {
               }}
             >
               <Typography fontWeight={600} sx={{ mb: 2 }}>
-                © Crossplane Authors 2022. Documentation distributed under{' '}
+                © Crossplane Authors 2023. Documentation distributed under{' '}
                 <Link
                   href={routes.creativeCommonsUrl}
                   muiProps={{ color: COLORS.turquoise, target: '_blank' }}
@@ -185,7 +185,7 @@ Props) => {
                 .
               </Typography>
               <Typography fontWeight={600}>
-                © 2022 The Linux Foundation. All rights reserved. The Linux Foundation has
+                © 2023 The Linux Foundation. All rights reserved. The Linux Foundation has
                 registered trademarks and uses trademarks. For a list of trademarks of The Linux
                 Foundation, please see our{' '}
                 <Link


### PR DESCRIPTION
After browsing the [Crossplane](https://crossplane.io) website I noticed that the trademark date was out of date.