### PR TITLE
Adding dynamic date in page footer

### DIFF
--- a/src/components/PageFooter.tsx
+++ b/src/components/PageFooter.tsx
@@ -81,6 +81,10 @@ type Props = {
   // ctaCustomSx?: SxProps;
 };
 
+const getCurrentYear = () => {
+  return new Date().getUTCFullYear();
+};
+
 const PageFooter = ({
   isFooterVisible = true,
   hideCTACard,
@@ -214,7 +218,7 @@ Props) => {
               }}
             >
               <Typography fontWeight={600} sx={{ mb: 2 }}>
-                © Crossplane Authors 2023. Documentation distributed under{' '}
+                © Crossplane Authors {getCurrentYear()}. Documentation distributed under{' '}
                 <Link
                   href={routes.creativeCommonsUrl}
                   muiProps={{ color: COLORS.turquoise, target: '_blank' }}
@@ -224,7 +228,7 @@ Props) => {
                 .
               </Typography>
               <Typography fontWeight={600}>
-                © 2023 The Linux Foundation. All rights reserved. The Linux Foundation has
+                © {getCurrentYear()} The Linux Foundation. All rights reserved. The Linux Foundation has
                 registered trademarks and uses trademarks. For a list of trademarks of The Linux
                 Foundation, please see our{' '}
                 <Link


### PR DESCRIPTION
I noticed that crossplane.io pages have a static year in the footer, currently outdated. Adding a dynamic generation of the date.