### PR TITLE
Remove news banner while there is no news to share

### DIFF
--- a/src/static-cms.ts
+++ b/src/static-cms.ts
@@ -1,4 +1,7 @@
-export const newsBannerData: NewsBanner | undefined = {
+export const newsBannerData: NewsBanner | undefined = undefined;
+/* commenting out the news banner while it is not being used, it can be added back by removing the comment
+   block and removing the assignment to undefined just above.
+{
   text:
     'New event! Level Up with Crossplane, presented by Upbound, goes deeper with Crossplane 1.15, compositions, ' +
     'testing patterns, and more.',
@@ -22,7 +25,7 @@ export const newsBannerData: NewsBanner | undefined = {
     },
   ],
   banner_id: '1-5',
-};
+}; */
 
 export const indexData: HomePage = {
   header: [


### PR DESCRIPTION
This PR attempts to temporarily remove the news banner while there is currently no news to share.

I'm not entirely sure what I'm doing, so we'll test this on the preview site.  I've attempted to comment out the content of the current news banner, so whoever comes along later to re-enable it with new news to share can do that very simply.

Feel free to suggest any other better way to do this 😅 