### PR TITLE
chore: update static copyright year in website footer

### DIFF
--- a/src/components/PageFooter.tsx
+++ b/src/components/PageFooter.tsx
@@ -214,7 +214,7 @@ Props) => {
               }}
             >
               <Typography fontWeight={600} sx={{ mb: 2 }}>
-                © Crossplane Authors 2023. Documentation distributed under{' '}
+                © Crossplane Authors 2024. Documentation distributed under{' '}
                 <Link
                   href={routes.creativeCommonsUrl}
                   muiProps={{ color: COLORS.turquoise, target: '_blank' }}
@@ -224,7 +224,7 @@ Props) => {
                 .
               </Typography>
               <Typography fontWeight={600}>
-                © 2023 The Linux Foundation. All rights reserved. The Linux Foundation has
+                © 2024 The Linux Foundation. All rights reserved. The Linux Foundation has
                 registered trademarks and uses trademarks. For a list of trademarks of The Linux
                 Foundation, please see our{' '}
                 <Link


### PR DESCRIPTION
While reading through your website, and checking the docs afterwards I realised that the year on the website is not up-to-date in comparison to the docs page.
- https://www.crossplane.io/ `2023`
- https://docs.crossplane.io/ `2024` (makes use of `© {{ now.Format "2006"}} ...`)

After checking the files history it seems like it got bumped manually last time as well https://github.com/crossplane/website/pull/43, therefore I am opening up this PR.

If desired I can also refactor the static copyright year to dynamic approach, via JS date object, that would reduce the manual efforts next time.
