### PR TITLE
chore: update links to community resources

### DIFF
--- a/pages/commercial.tsx
+++ b/pages/commercial.tsx
@@ -285,7 +285,7 @@ const Why = () => {
             <Typography variant="body_normal" sx={{ whiteSpace: 'break-spaces' }}>
               Building on top of Crossplane or offering support? {'\n'}
               <Link
-                href="mailto:info@crossplane.io"
+                href="mailto:crossplane-info@lists.cncf.io"
                 muiProps={{
                   target: '_blank',
                   fontWeight: 700,

--- a/src/components/PageHead.tsx
+++ b/src/components/PageHead.tsx
@@ -71,7 +71,7 @@ const PageHead: React.FC<{
             "@context": "https://schema.org",
             "@type": "Organization",
             "name": "Crossplane",
-            "email": "info@crossplane.io",
+            "email": "crossplane-info@lists.cncf.io",
             "foundingDate": "December 2018",
             "description": "Create platforms like cloud providers by building your own APIs and services with control planes, extening Kubernetes to manage any resource anywhere, and using a library of components to assemble your platform faster.",
             "memberOf": {


### PR DESCRIPTION
This PR simply updates the README and other locations to point to newly migrated community accounts owned by the CNCF, e.g. email addresses, community calendars, etc.